### PR TITLE
Minor instrumentation change that highlights the configured vhost for AMQP Q Consumer.

### DIFF
--- a/src/com/urbanairship/octobot/QueueConsumer.java
+++ b/src/com/urbanairship/octobot/QueueConsumer.java
@@ -237,7 +237,7 @@ public boolean invokeTask(String rawMessage) {
     // if the queue server is unavailable.
     private Channel getAMQPChannel(Queue queue) {
         int attempts = 0;
-        logger.info("Opening connection to AMQP / " + queue.queueName + "...");
+        logger.info("Opening connection to AMQP " + queue.vhost + " "  + queue.queueName + "...");
 
         while (true) {
             attempts++;


### PR DESCRIPTION
I'm new to both Octobot and RabbitMQ.  I wanted to learn how to create my own vhost/user/permissions etc. in RabbitMQ and correspondingly switch Octobot's configuration for a worker.  When Octobot kept failing I believed it was because Octobot was using the default vhost.  I.e. watching the log output it showed the default vhost was being used.  So I debugged it enough to find that Octobot was in fact using the configured vhost and that the logging statement was in fact hard coded.  

This pull request will simply fix the logging output to dump the configured vhost.
